### PR TITLE
Aim multicont adjustments

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -749,9 +749,7 @@ void advanced_inventory::recalc_pane( side p )
     if( there.container ) {
         std::vector<advanced_inv_listitem>::iterator outer_iter = pane.items.begin();
         while( outer_iter != pane.items.end() ) {
-            if( *outer_iter->items.begin() == there.container ||
-                there.container.eventually_contains( *outer_iter->items.begin() ) ) {
-
+            if( *outer_iter->items.begin() == there.container ) {
                 outer_iter = pane.items.erase( outer_iter );
             } else {
                 outer_iter++;
@@ -1271,10 +1269,6 @@ void advanced_inventory::start_activity(
     } else {
         if( !panes[dest].container.get_item() ) {
             debugmsg( "Active container is null, failed to insert!" );
-            return;
-        }
-        if( panes[dest].container.eventually_contains( sitem->items.front() ) ) {
-            debugmsg( _( "The %s is already inside that container!" ), sitem->items.front()->tname() );
             return;
         }
         if( panes[dest].container->will_spill_if_unsealed()

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -109,7 +109,6 @@ void advanced_inv_area::init()
             }
             break;
         case AIM_CONTAINER:
-        case AIM_CONTAINER2:
             // set container position based on location
             set_container_position();
             // location always valid, actual check is done in canputitems()
@@ -207,8 +206,7 @@ bool advanced_inv_area::is_same( const advanced_inv_area &other ) const
     // e.g. dragged vehicle (to the south) and AIM_SOUTH are the same.
     if( id != AIM_INVENTORY && other.id != AIM_INVENTORY &&
         id != AIM_WORN && other.id != AIM_WORN &&
-        ( id != AIM_CONTAINER && other.id != AIM_CONTAINER ) &&
-        ( id != AIM_CONTAINER2 && other.id != AIM_CONTAINER2 ) ) {
+        id != AIM_CONTAINER && other.id != AIM_CONTAINER ) {
         //     have a vehicle?...     ...do the cargo index and pos match?...    ...at least pos?
         return veh == other.veh ? pos == other.pos && vstor == other.vstor : pos == other.pos;
     }
@@ -220,8 +218,7 @@ bool advanced_inv_area::canputitems( const item_location &container ) const
 {
     bool canputitems = false;
     switch( id ) {
-        case AIM_CONTAINER:
-        case AIM_CONTAINER2: {
+        case AIM_CONTAINER: {
             if( container ) {
                 if( container.get_item()->is_container() ) {
                     canputitems = true;

--- a/src/advanced_inv_area.h
+++ b/src/advanced_inv_area.h
@@ -24,7 +24,6 @@ enum aim_location : char {
     AIM_DRAGGED,
     AIM_ALL,
     AIM_CONTAINER,
-    AIM_CONTAINER2,
     AIM_WORN,
     NUM_AIM_LOCATIONS,
     // only useful for AIM_ALL

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -216,7 +216,7 @@ void advanced_inventory_pane::add_items_from_area( advanced_inv_area &square,
         }
 
         u.worn.add_AIM_items_from_area( u, square, *this );
-    } else if( square.id == AIM_CONTAINER || square.id == AIM_CONTAINER2 ) {
+    } else if( square.id == AIM_CONTAINER ) {
         square.volume = 0_ml;
         square.weight = 0_gram;
         if( container ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There were a few issues I noticed: 
- The way items are hidden between panels makes it difficult to work with nested containers now that that's possible.
- The header's [C]'s color changing behavior would act differently between the panes if they were both looking in containers.
- The doubling of the container location with AIM_CONTAINER2 is functional, but I wanted to see if there was a simpler solution.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds an alternative is_same check for container views in action_move_item(), which does the same job that AIM_CONTAINER2 was accomplishing, letting me revert everything back to using the single AIM_CONTAINER. Doing this also fixed the [C] header and required me to change how volume/weight were calculated. After that I changed the item hiding to be more lenient and removed a now-unnecessary debugmsg.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->